### PR TITLE
Unpin regex version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.9.0"
 dependencies = [
-    "regex==2024.11.6"
+    "regex>=2024.11.6"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Regex uses `CalVer`, pinning it to a specific release makes it difficult for downstream packages to update and use newer versions, e.g. `2025.7.29` added wheels for Python 3.14.

https://github.com/mrabarnett/mrab-regex/blob/hg/changelog.txt

--
Would be awesome to have a new release after this is done, so it can be updated in Home Assistant.